### PR TITLE
Make tests green

### DIFF
--- a/src/Micrometa/Tests/AbstractTestBase.php
+++ b/src/Micrometa/Tests/AbstractTestBase.php
@@ -64,9 +64,9 @@ abstract class AbstractTestBase extends TestCase
      */
     private static $logger;
 
-    protected static function getLogger() : LoggerInterface
+    protected static function getLogger(int $threshold = 400) : LoggerInterface
     {
-        return self::$logger ?? self::$logger = new ExceptionLogger();
+        return self::$logger[$threshold] ?? self::$logger[$threshold] = new ExceptionLogger($threshold);
     }
 
     /**

--- a/src/Micrometa/Tests/AbstractTestBase.php
+++ b/src/Micrometa/Tests/AbstractTestBase.php
@@ -55,21 +55,18 @@ abstract class AbstractTestBase extends TestCase
      *
      * @var string
      */
-    protected static $fixture;
+    protected static $fixture =  __DIR__.DIRECTORY_SEPARATOR.'Fixture'.DIRECTORY_SEPARATOR;
+
     /**
      * Logger
      *
      * @var LoggerInterface
      */
-    protected static $logger;
+    private static $logger;
 
-    /**
-     * Setup
-     */
-    public static function setUpBeforeClass()
+    protected static function getLogger() : LoggerInterface
     {
-        self::$fixture = __DIR__.DIRECTORY_SEPARATOR.'Fixture'.DIRECTORY_SEPARATOR;
-        self::$logger  = new ExceptionLogger();
+        return self::$logger ?? self::$logger = new ExceptionLogger();
     }
 
     /**

--- a/src/Micrometa/Tests/Application/ExtractorTest.php
+++ b/src/Micrometa/Tests/Application/ExtractorTest.php
@@ -56,23 +56,6 @@ use League\Uri\Http;
 class ExtractorTest extends AbstractTestBase
 {
     /**
-     * Microformats tests root path
-     *
-     * @var string
-     */
-    protected static $microformatsTests;
-
-    /**
-     * Setup before all tests
-     */
-    public static function setUpBeforeClass()
-    {
-        parent::setUpBeforeClass();
-        self::$microformatsTests = \ComposerLocator::getPath('mf2/tests').DIRECTORY_SEPARATOR.'tests'.
-                                   DIRECTORY_SEPARATOR.'microformats-v2'.DIRECTORY_SEPARATOR;
-    }
-
-    /**
      * Test the RDFa Lite 1.1 extraction
      */
     public function testRdfaLiteExtraction()
@@ -82,7 +65,7 @@ class ExtractorTest extends AbstractTestBase
         $this->assertInstanceOf(\DOMDocument::class, $rdfaLiteDom);
 
         // Create an RDFa Lite 1.1 parser
-        $rdfaLiteParser = new RdfaLite($rdfaLiteUri, self::$logger);
+        $rdfaLiteParser = new RdfaLite($rdfaLiteUri, self::getLogger());
         $this->assertEquals($rdfaLiteUri, $rdfaLiteParser->getUri());
 
         // Create an extractor service
@@ -121,8 +104,11 @@ class ExtractorTest extends AbstractTestBase
      */
     public function testMicroformatsExtraction()
     {
+        $microformatsTests = \ComposerLocator::getPath('mf2/tests').DIRECTORY_SEPARATOR.'tests'.
+            DIRECTORY_SEPARATOR.'microformats-v2'.DIRECTORY_SEPARATOR;
+
         $this->getAndTestMicroformatsExtractionBase(
-            self::$microformatsTests.'h-product'.DIRECTORY_SEPARATOR.'aggregate.html'
+            $microformatsTests.'h-product'.DIRECTORY_SEPARATOR.'aggregate.html'
         );
     }
 

--- a/src/Micrometa/Tests/Infrastructure/ParserFactoryTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserFactoryTest.php
@@ -61,7 +61,7 @@ class ParserFactoryTest extends AbstractTestBase
     {
         $formats = Microformats::FORMAT | Microdata::FORMAT | JsonLD::FORMAT | RdfaLite::FORMAT | LinkType::FORMAT;
         $uri     = 'http://localhost/example.html';
-        $parsers = ParserFactory::createParsersFromFormats($formats, Http::createFromString($uri), self::$logger);
+        $parsers = ParserFactory::createParsersFromFormats($formats, Http::createFromString($uri), self::getLogger());
 
         /**
          * @var int $parserFormat

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -143,11 +143,10 @@ class ParserTest extends AbstractTestBase
         list($uri, $dom) = $this->getUriFixture('html-microdata/article-microdata.html');
         $parser = new Microdata($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
-        $this->assertTrue(is_array($items));
-        $this->assertEquals(1, count($items));
-        $this->assertInstanceOf(Item::class, $items[0]);
-        $this->assertEquals(Microdata::FORMAT, $items[0]->getFormat());
-        $this->assertEquals([new Iri('http://schema.org/', 'NewsArticle')], $items[0]->getType());
+
+        $expectedItemFormat = Microdata::FORMAT;
+        $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
+        $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
     }
 
     /**
@@ -158,11 +157,10 @@ class ParserTest extends AbstractTestBase
         list($uri, $dom) = $this->getUriFixture('rdfa-lite/article-rdfa-lite.html');
         $parser = new RdfaLite($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
-        $this->assertTrue(is_array($items));
-        $this->assertEquals(1, count($items));
-        $this->assertInstanceOf(Item::class, $items[0]);
-        $this->assertEquals(RdfaLite::FORMAT, $items[0]->getFormat());
-        $this->assertEquals([new Iri('http://schema.org/', 'NewsArticle')], $items[0]->getType());
+
+        $expectedItemFormat = RdfaLite::FORMAT;
+        $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
+        $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
     }
 
     /**
@@ -178,5 +176,14 @@ class ParserTest extends AbstractTestBase
         $this->assertInstanceOf(Item::class, $items[0]);
         $this->assertEquals(LinkType::FORMAT, $items[0]->getFormat());
         $this->assertEquals([new Iri(LinkType::HTML_PROFILE_URI, 'icon')], $items[0]->getType());
+    }
+
+    private function assertItemParsedAs(array $items, int $expectedItemFormat, Iri $expectedItemIri)
+    {
+        $this->assertIsArray($items);
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(Item::class, $items[0]);
+        $this->assertEquals($expectedItemFormat, $items[0]->getFormat());
+        $this->assertEquals([$expectedItemIri], $items[0]->getType());
     }
 }

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -60,9 +60,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testLanguageJsonLDParser()
     {
-        list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-languages.html');
-        $parser = new JsonLD($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('json-ld/jsonld-languages.html', JsonLD::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -84,9 +82,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testMultipleJsonLDParser()
     {
-        list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-examples.html');
-        $parser = new JsonLD($uri, new ExceptionLogger(0));
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('json-ld/jsonld-examples.html', JsonLD::class, 0);
         $this->assertTrue(is_array($items));
         $this->assertEquals(5, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -99,9 +95,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testInvalidJsonLDParser()
     {
-        list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-invalid.html');
-        $parser = new JsonLD($uri, new ExceptionLogger(0));
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('json-ld/jsonld-invalid.html', JsonLD::class, 0);
         $this->assertTrue(is_array($items));
         $this->assertEquals(0, count($items));
     }
@@ -111,9 +105,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testMicroformatsParser()
     {
-        list($uri, $dom) = $this->getUriFixture('microformats/entry.html');
-        $parser = new Microformats($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('microformats/entry.html', Microformats::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -125,9 +117,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testNestedMicroformatsParser()
     {
-        list($uri, $dom) = $this->getUriFixture('microformats/nested-events.html');
-        $parser = new Microformats($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('microformats/nested-events.html', Microformats::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -140,10 +130,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testMicrodataParser()
     {
-        list($uri, $dom) = $this->getUriFixture('html-microdata/article-microdata.html');
-        $parser = new Microdata($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
-
+        $items = $this->parseItems('html-microdata/article-microdata.html', Microdata::class);
         $expectedItemFormat = Microdata::FORMAT;
         $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
         $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
@@ -154,10 +141,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testRdfaLiteParser()
     {
-        list($uri, $dom) = $this->getUriFixture('rdfa-lite/article-rdfa-lite.html');
-        $parser = new RdfaLite($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
-
+        $items = $this->parseItems('rdfa-lite/article-rdfa-lite.html', RdfaLite::class);
         $expectedItemFormat = RdfaLite::FORMAT;
         $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
         $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
@@ -168,9 +152,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testLinkTypeParser()
     {
-        list($uri, $dom) = $this->getUriFixture('link-type/valid-test.html');
-        $parser = new LinkType($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('link-type/valid-test.html', LinkType::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(4, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -185,5 +167,12 @@ class ParserTest extends AbstractTestBase
         $this->assertInstanceOf(Item::class, $items[0]);
         $this->assertEquals($expectedItemFormat, $items[0]->getFormat());
         $this->assertEquals([$expectedItemIri], $items[0]->getType());
+    }
+
+    private function parseItems(string $fixture, string $parser, int $errorThreshold = 400)
+    {
+        list($uri, $dom) = $this->getUriFixture($fixture);
+        $parser = new $parser($uri, self::getLogger($errorThreshold));
+        return $parser->parseDom($dom)->getItems();
     }
 }

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -61,7 +61,7 @@ class ParserTest extends AbstractTestBase
     public function testLanguageJsonLDParser()
     {
         list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-languages.html');
-        $parser = new JsonLD($uri, self::$logger);
+        $parser = new JsonLD($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -112,7 +112,7 @@ class ParserTest extends AbstractTestBase
     public function testMicroformatsParser()
     {
         list($uri, $dom) = $this->getUriFixture('microformats/entry.html');
-        $parser = new Microformats($uri, self::$logger);
+        $parser = new Microformats($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -126,7 +126,7 @@ class ParserTest extends AbstractTestBase
     public function testNestedMicroformatsParser()
     {
         list($uri, $dom) = $this->getUriFixture('microformats/nested-events.html');
-        $parser = new Microformats($uri, self::$logger);
+        $parser = new Microformats($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -141,7 +141,7 @@ class ParserTest extends AbstractTestBase
     public function testMicrodataParser()
     {
         list($uri, $dom) = $this->getUriFixture('html-microdata/article-microdata.html');
-        $parser = new Microdata($uri, self::$logger);
+        $parser = new Microdata($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -156,7 +156,7 @@ class ParserTest extends AbstractTestBase
     public function testRdfaLiteParser()
     {
         list($uri, $dom) = $this->getUriFixture('rdfa-lite/article-rdfa-lite.html');
-        $parser = new RdfaLite($uri, self::$logger);
+        $parser = new RdfaLite($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -171,7 +171,7 @@ class ParserTest extends AbstractTestBase
     public function testLinkTypeParser()
     {
         list($uri, $dom) = $this->getUriFixture('link-type/valid-test.html');
-        $parser = new LinkType($uri, self::$logger);
+        $parser = new LinkType($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(4, count($items));


### PR DESCRIPTION
Overriding `setUpBeforeClass` causes PHP language conflicts. As result, tests are failing on `master`.