### PR TITLE
Sanitize JSON-LD input before decoding

### DIFF
--- a/src/Micrometa/Infrastructure/Parser/JsonLD.php
+++ b/src/Micrometa/Infrastructure/Parser/JsonLD.php
@@ -134,6 +134,8 @@ class JsonLD extends AbstractParser
      */
     protected function parseDocument($jsonLDDocSource)
     {
+        $jsonLDDocSource = $this->sanitizeJsonSource($jsonLDDocSource);
+
         // Unserialize the JSON-LD document
         $jsonLDDoc = @json_decode($jsonLDDocSource);
 
@@ -338,5 +340,16 @@ class JsonLD extends AbstractParser
     protected function parseTypedValue(TypedValue $value)
     {
         return $value->getValue();
+    }
+
+    private function sanitizeJsonSource($jsonLDDocSource)
+    {
+        $jsonLDDocSource = trim($jsonLDDocSource);
+
+        if (substr($jsonLDDocSource, -1) === ';') {
+            $jsonLDDocSource = substr_replace($jsonLDDocSource, '', -1);
+        }
+
+        return $jsonLDDocSource;
     }
 }

--- a/src/Micrometa/Tests/AbstractTestBase.php
+++ b/src/Micrometa/Tests/AbstractTestBase.php
@@ -64,9 +64,9 @@ abstract class AbstractTestBase extends TestCase
      */
     private static $logger;
 
-    protected static function getLogger() : LoggerInterface
+    protected static function getLogger(int $threshold = 400) : LoggerInterface
     {
-        return self::$logger ?? self::$logger = new ExceptionLogger();
+        return self::$logger[$threshold] ?? self::$logger[$threshold] = new ExceptionLogger($threshold);
     }
 
     /**

--- a/src/Micrometa/Tests/AbstractTestBase.php
+++ b/src/Micrometa/Tests/AbstractTestBase.php
@@ -55,21 +55,18 @@ abstract class AbstractTestBase extends TestCase
      *
      * @var string
      */
-    protected static $fixture;
+    protected static $fixture =  __DIR__.DIRECTORY_SEPARATOR.'Fixture'.DIRECTORY_SEPARATOR;
+
     /**
      * Logger
      *
      * @var LoggerInterface
      */
-    protected static $logger;
+    private static $logger;
 
-    /**
-     * Setup
-     */
-    public static function setUpBeforeClass()
+    protected static function getLogger() : LoggerInterface
     {
-        self::$fixture = __DIR__.DIRECTORY_SEPARATOR.'Fixture'.DIRECTORY_SEPARATOR;
-        self::$logger  = new ExceptionLogger();
+        return self::$logger ?? self::$logger = new ExceptionLogger();
     }
 
     /**

--- a/src/Micrometa/Tests/Application/ExtractorTest.php
+++ b/src/Micrometa/Tests/Application/ExtractorTest.php
@@ -56,23 +56,6 @@ use League\Uri\Http;
 class ExtractorTest extends AbstractTestBase
 {
     /**
-     * Microformats tests root path
-     *
-     * @var string
-     */
-    protected static $microformatsTests;
-
-    /**
-     * Setup before all tests
-     */
-    public static function setUpBeforeClass()
-    {
-        parent::setUpBeforeClass();
-        self::$microformatsTests = \ComposerLocator::getPath('mf2/tests').DIRECTORY_SEPARATOR.'tests'.
-                                   DIRECTORY_SEPARATOR.'microformats-v2'.DIRECTORY_SEPARATOR;
-    }
-
-    /**
      * Test the RDFa Lite 1.1 extraction
      */
     public function testRdfaLiteExtraction()
@@ -82,7 +65,7 @@ class ExtractorTest extends AbstractTestBase
         $this->assertInstanceOf(\DOMDocument::class, $rdfaLiteDom);
 
         // Create an RDFa Lite 1.1 parser
-        $rdfaLiteParser = new RdfaLite($rdfaLiteUri, self::$logger);
+        $rdfaLiteParser = new RdfaLite($rdfaLiteUri, self::getLogger());
         $this->assertEquals($rdfaLiteUri, $rdfaLiteParser->getUri());
 
         // Create an extractor service
@@ -121,8 +104,11 @@ class ExtractorTest extends AbstractTestBase
      */
     public function testMicroformatsExtraction()
     {
+        $microformatsTests = \ComposerLocator::getPath('mf2/tests').DIRECTORY_SEPARATOR.'tests'.
+            DIRECTORY_SEPARATOR.'microformats-v2'.DIRECTORY_SEPARATOR;
+
         $this->getAndTestMicroformatsExtractionBase(
-            self::$microformatsTests.'h-product'.DIRECTORY_SEPARATOR.'aggregate.html'
+            $microformatsTests.'h-product'.DIRECTORY_SEPARATOR.'aggregate.html'
         );
     }
 

--- a/src/Micrometa/Tests/Fixture/json-ld/jsonld-ending-semicolon.html
+++ b/src/Micrometa/Tests/Fixture/json-ld/jsonld-ending-semicolon.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta charset="UTF-8">
+        <title>JSON-LD test document</title>
+        <script type="application/ld+json">
+            {
+                "@context": {
+                    "t1": "http://example.com/t1"
+                },
+                "@id": "http://example.com/id1",
+                "@type": "t1"
+            };
+        </script>
+    </head>
+    <body>
+        <h1>JSON-LD test document</h1>
+    </body>
+</html>

--- a/src/Micrometa/Tests/Infrastructure/ParserFactoryTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserFactoryTest.php
@@ -61,7 +61,7 @@ class ParserFactoryTest extends AbstractTestBase
     {
         $formats = Microformats::FORMAT | Microdata::FORMAT | JsonLD::FORMAT | RdfaLite::FORMAT | LinkType::FORMAT;
         $uri     = 'http://localhost/example.html';
-        $parsers = ParserFactory::createParsersFromFormats($formats, Http::createFromString($uri), self::$logger);
+        $parsers = ParserFactory::createParsersFromFormats($formats, Http::createFromString($uri), self::getLogger());
 
         /**
          * @var int $parserFormat

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -143,11 +143,10 @@ class ParserTest extends AbstractTestBase
         list($uri, $dom) = $this->getUriFixture('html-microdata/article-microdata.html');
         $parser = new Microdata($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
-        $this->assertTrue(is_array($items));
-        $this->assertEquals(1, count($items));
-        $this->assertInstanceOf(Item::class, $items[0]);
-        $this->assertEquals(Microdata::FORMAT, $items[0]->getFormat());
-        $this->assertEquals([new Iri('http://schema.org/', 'NewsArticle')], $items[0]->getType());
+
+        $expectedItemFormat = Microdata::FORMAT;
+        $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
+        $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
     }
 
     /**
@@ -158,11 +157,10 @@ class ParserTest extends AbstractTestBase
         list($uri, $dom) = $this->getUriFixture('rdfa-lite/article-rdfa-lite.html');
         $parser = new RdfaLite($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
-        $this->assertTrue(is_array($items));
-        $this->assertEquals(1, count($items));
-        $this->assertInstanceOf(Item::class, $items[0]);
-        $this->assertEquals(RdfaLite::FORMAT, $items[0]->getFormat());
-        $this->assertEquals([new Iri('http://schema.org/', 'NewsArticle')], $items[0]->getType());
+
+        $expectedItemFormat = RdfaLite::FORMAT;
+        $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
+        $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
     }
 
     /**
@@ -178,5 +176,14 @@ class ParserTest extends AbstractTestBase
         $this->assertInstanceOf(Item::class, $items[0]);
         $this->assertEquals(LinkType::FORMAT, $items[0]->getFormat());
         $this->assertEquals([new Iri(LinkType::HTML_PROFILE_URI, 'icon')], $items[0]->getType());
+    }
+
+    private function assertItemParsedAs(array $items, int $expectedItemFormat, Iri $expectedItemIri)
+    {
+        $this->assertIsArray($items);
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(Item::class, $items[0]);
+        $this->assertEquals($expectedItemFormat, $items[0]->getFormat());
+        $this->assertEquals([$expectedItemIri], $items[0]->getType());
     }
 }

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -60,9 +60,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testLanguageJsonLDParser()
     {
-        list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-languages.html');
-        $parser = new JsonLD($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('json-ld/jsonld-languages.html', JsonLD::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -84,9 +82,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testMultipleJsonLDParser()
     {
-        list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-examples.html');
-        $parser = new JsonLD($uri, new ExceptionLogger(0));
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('json-ld/jsonld-examples.html', JsonLD::class, 0);
         $this->assertTrue(is_array($items));
         $this->assertEquals(5, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -99,9 +95,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testInvalidJsonLDParser()
     {
-        list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-invalid.html');
-        $parser = new JsonLD($uri, new ExceptionLogger(0));
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('json-ld/jsonld-invalid.html', JsonLD::class, 0);
         $this->assertTrue(is_array($items));
         $this->assertEquals(0, count($items));
     }
@@ -111,9 +105,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testMicroformatsParser()
     {
-        list($uri, $dom) = $this->getUriFixture('microformats/entry.html');
-        $parser = new Microformats($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('microformats/entry.html', Microformats::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -125,9 +117,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testNestedMicroformatsParser()
     {
-        list($uri, $dom) = $this->getUriFixture('microformats/nested-events.html');
-        $parser = new Microformats($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('microformats/nested-events.html', Microformats::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -140,10 +130,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testMicrodataParser()
     {
-        list($uri, $dom) = $this->getUriFixture('html-microdata/article-microdata.html');
-        $parser = new Microdata($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
-
+        $items = $this->parseItems('html-microdata/article-microdata.html', Microdata::class);
         $expectedItemFormat = Microdata::FORMAT;
         $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
         $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
@@ -154,10 +141,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testRdfaLiteParser()
     {
-        list($uri, $dom) = $this->getUriFixture('rdfa-lite/article-rdfa-lite.html');
-        $parser = new RdfaLite($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
-
+        $items = $this->parseItems('rdfa-lite/article-rdfa-lite.html', RdfaLite::class);
         $expectedItemFormat = RdfaLite::FORMAT;
         $expectedItemIri = new Iri('http://schema.org/', 'NewsArticle');
         $this->assertItemParsedAs($items, $expectedItemFormat, $expectedItemIri);
@@ -168,9 +152,7 @@ class ParserTest extends AbstractTestBase
      */
     public function testLinkTypeParser()
     {
-        list($uri, $dom) = $this->getUriFixture('link-type/valid-test.html');
-        $parser = new LinkType($uri, self::getLogger());
-        $items  = $parser->parseDom($dom)->getItems();
+        $items = $this->parseItems('link-type/valid-test.html', LinkType::class);
         $this->assertTrue(is_array($items));
         $this->assertEquals(4, count($items));
         $this->assertInstanceOf(Item::class, $items[0]);
@@ -185,5 +167,12 @@ class ParserTest extends AbstractTestBase
         $this->assertInstanceOf(Item::class, $items[0]);
         $this->assertEquals($expectedItemFormat, $items[0]->getFormat());
         $this->assertEquals([$expectedItemIri], $items[0]->getType());
+    }
+
+    private function parseItems(string $fixture, string $parser, int $errorThreshold = 400)
+    {
+        list($uri, $dom) = $this->getUriFixture($fixture);
+        $parser = new $parser($uri, self::getLogger($errorThreshold));
+        return $parser->parseDom($dom)->getItems();
     }
 }

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -101,6 +101,18 @@ class ParserTest extends AbstractTestBase
     }
 
     /**
+     * Test the JSON-LD parser with an invalid document
+     */
+    public function testFixOnSemicolonForJsonLDParser()
+    {
+        list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-ending-semicolon.html');
+        $parser = new JsonLD($uri, new ExceptionLogger(0));
+        $items  = $parser->parseDom($dom)->getItems();
+        $this->assertTrue(is_array($items));
+        $this->assertEquals(1, count($items));
+    }
+
+    /**
      * Test the Microformats parser
      */
     public function testMicroformatsParser()

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -61,7 +61,7 @@ class ParserTest extends AbstractTestBase
     public function testLanguageJsonLDParser()
     {
         list($uri, $dom) = $this->getUriFixture('json-ld/jsonld-languages.html');
-        $parser = new JsonLD($uri, self::$logger);
+        $parser = new JsonLD($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -112,7 +112,7 @@ class ParserTest extends AbstractTestBase
     public function testMicroformatsParser()
     {
         list($uri, $dom) = $this->getUriFixture('microformats/entry.html');
-        $parser = new Microformats($uri, self::$logger);
+        $parser = new Microformats($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -126,7 +126,7 @@ class ParserTest extends AbstractTestBase
     public function testNestedMicroformatsParser()
     {
         list($uri, $dom) = $this->getUriFixture('microformats/nested-events.html');
-        $parser = new Microformats($uri, self::$logger);
+        $parser = new Microformats($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -141,7 +141,7 @@ class ParserTest extends AbstractTestBase
     public function testMicrodataParser()
     {
         list($uri, $dom) = $this->getUriFixture('html-microdata/article-microdata.html');
-        $parser = new Microdata($uri, self::$logger);
+        $parser = new Microdata($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -156,7 +156,7 @@ class ParserTest extends AbstractTestBase
     public function testRdfaLiteParser()
     {
         list($uri, $dom) = $this->getUriFixture('rdfa-lite/article-rdfa-lite.html');
-        $parser = new RdfaLite($uri, self::$logger);
+        $parser = new RdfaLite($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(1, count($items));
@@ -171,7 +171,7 @@ class ParserTest extends AbstractTestBase
     public function testLinkTypeParser()
     {
         list($uri, $dom) = $this->getUriFixture('link-type/valid-test.html');
-        $parser = new LinkType($uri, self::$logger);
+        $parser = new LinkType($uri, self::getLogger());
         $items  = $parser->parseDom($dom)->getItems();
         $this->assertTrue(is_array($items));
         $this->assertEquals(4, count($items));


### PR DESCRIPTION
This PR relies on #38 getting merged, as commit e4e9a18fbefda704ffb18249f1e15f797f6b21a0 is the commit that fixes the bug

When the Json ends with a `;` the json can not get decoded.

## Example

WHO content ends with an `;`. As result of that the `NewsArticle` can not get parsed.

https://www.who.int/news-room/detail/17-10-2019-7-million-people-receive-record-levels-of-lifesaving-tb-treatment-but-3-million-still-miss-out

## How to test

Run while parsing above URL 

Or test the following JSON snippet on [https://jsonlint.com/#](https://jsonlint.com/#):

```json
{"author":{"@type":"Organization","name":"World Health Organization: WHO","logo":{"@type":"ImageObject","url":"http://www.who.int/Images/SchemaOrg/schemaOrgLogo.jpg","width":250,"height":60}},"headline":"7 million people receive record levels of lifesaving TB treatment but 3 million still miss out","description":"<p>More people received life-saving treatment for tuberculosis (TB) in 2018 than ever before, largely due to improved detection and diagnosis. Globally, 7 million people were diagnosed and treated for TB - up from 6.4 million in 2017 &ndash; enabling the world to meet one of the milestones towards the United Nations political declaration targets on TB. </p> [...] <p>Brazil, China, the Russian Federation and Zimbabwe, which all have high TB burdens, achieved treatment coverage levels of more than 80 per cent.</p>","datePublished":"2019-10-17T22:01:00.0000000+00:00","image":"https://www.who.int/images/default-source/wpro/news/feature-stories/cambodia-tb-screening.jpg?sfvrsn=e7bbe3fb_20","publisher":{"@type":"Organization","name":"World Health Organization: WHO","logo":{"@type":"ImageObject","url":"http://www.who.int/Images/SchemaOrg/schemaOrgLogo.jpg","width":250,"height":60}},"dateModified":"2019-10-17T22:01:00.0000000+00:00","mainEntityOfPage":"https://www.who.int/news-room/detail/17-10-2019-7-million-people-receive-record-levels-of-lifesaving-tb-treatment-but-3-million-still-miss-out","@context":"http://schema.org","@type":"NewsArticle"};
```

## How to fix

check if the last character is a `;`, and strip that