### PR TITLE
Support additional return options of `node->getType`

### DIFF
--- a/src/Micrometa/Infrastructure/Parser/JsonLD.php
+++ b/src/Micrometa/Infrastructure/Parser/JsonLD.php
@@ -201,10 +201,23 @@ class JsonLD extends AbstractParser
      *
      * @return array Item type
      */
-    protected function parseNodeType(NodeInterface $node)
+    protected function parseNodeType(NodeInterface $node): array
     {
-        /** @var Node $itemType */
-        return ($itemType = $node->getType()) ? [$this->vocabularyCache->expandIRI($itemType->getId())] : [];
+        /** @var NodeInterface|NodeInterface[] $itemTypes */
+        $itemTypes = $node->getType();
+        $itemTypes = is_array($itemTypes) ? $itemTypes : [$itemTypes];
+        $itemTypes = array_filter($itemTypes);
+
+        if (empty($itemTypes)) {
+            return [];
+        }
+
+        $types = [];
+        foreach ($itemTypes as $itemType) {
+            $types[] = $this->vocabularyCache->expandIRI($itemType->getId());
+        }
+
+        return $types;
     }
 
     /**


### PR DESCRIPTION
fixes #43

Add support for two additional return types of `node->getType`:

* where it returns `NodeInterface[]`,
* where it returns `null`
* where one of the values of the returned `NodeInterface[]` was `null`