### PR TITLE
Fix #45, blank nodes

### DIFF
--- a/src/Micrometa/Infrastructure/Parser/JsonLD.php
+++ b/src/Micrometa/Infrastructure/Parser/JsonLD.php
@@ -201,8 +201,12 @@ class JsonLD extends AbstractParser
      *
      * @return array Item type
      */
-    protected function parseNodeType(NodeInterface $node)
+    protected function parseNodeType(NodeInterface $node): array
     {
+        if ($node->isBlankNode()) {
+            return [];
+        }
+
         /** @var Node $itemType */
         return ($itemType = $node->getType()) ? [$this->vocabularyCache->expandIRI($itemType->getId())] : [];
     }


### PR DESCRIPTION
Fixes #45

`ML\JsonLD` uses `_:` (followed by an identifier) to mark references, and the ones starting with `_:b` are `BlankNodes`.

https://github.com/lanthaler/JsonLD/blob/1.1.0/Node.php#L173-L176

https://github.com/lanthaler/JsonLD/blob/1.1.0/Graph.php#L248-L251