### PR TITLE
[RFC] Do not make iteminterface traversable by extending list

### DIFF
--- a/src/Micrometa/Ports/Item/ItemInterface.php
+++ b/src/Micrometa/Ports/Item/ItemInterface.php
@@ -45,7 +45,7 @@ use Jkphl\Micrometa\Application\Item\PropertyListInterface;
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Ports
  */
-interface ItemInterface extends ItemListInterface
+interface ItemInterface
 {
     /**
      * Return whether the item is of a particular type (or contained in a list of types)


### PR DESCRIPTION
see #50

An `item` not necessarily is a `list` itself. Making this explicit improves use cases where this difference is required.

When removing the interface from the port, tests still pass. This is not a BC break as `/Ports` can be considered internal