### PR TITLE
Support Monolog 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "league/uri": "^5.0",
         "mf2/mf2": "^0.4",
         "ml/json-ld": "^1.1",
-        "monolog/monolog": "^1.24",
+        "monolog/monolog": "^1.24 || ^2",
         "psr/cache": "^1.0",
         "psr/log": "^1.1",
         "symfony/cache": "^4.0"

--- a/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
+++ b/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
@@ -39,6 +39,9 @@ namespace Jkphl\Micrometa\Infrastructure\Logger;
 use Jkphl\Micrometa\Ports\Exceptions\RuntimeException;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
+use Monolog\ResettableInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
 
 /**
  * Exception logger
@@ -46,8 +49,10 @@ use Monolog\Logger;
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Infrastructure
  */
-class ExceptionLogger extends Logger
+final class ExceptionLogger implements LoggerInterface, ResettableInterface
 {
+    use LoggerTrait;
+
     /**
      * Exception threshold
      *
@@ -55,13 +60,15 @@ class ExceptionLogger extends Logger
      */
     protected $threshold;
 
+    private $decoratedLogger;
+
     /**
      * Constructor
      */
     public function __construct($threshold = Logger::ERROR)
     {
         $this->threshold = $threshold;
-        parent::__construct('exception', [new NullHandler()]);
+        $this->decoratedLogger = new Logger('exception', [new NullHandler()]);
     }
 
     /**
@@ -74,15 +81,15 @@ class ExceptionLogger extends Logger
      * @throws \Exception Exception that occured
      * @throws \RuntimeException Log message as exception
      */
-    public function addRecord($level, $message, array $context = [])
+    public function log($level, $message, array $context = [])
     {
-        $processed = parent::addRecord($level, $message, $context);
+        $level = Logger::toMonologLevel($level);
 
         if ($this->isTriggered($level)) {
             throw $this->getContextException($context) ?: new RuntimeException($message, $level);
         }
 
-        return $processed;
+        $this->decoratedLogger->addRecord($level, $message, $context);
     }
 
     /**
@@ -108,5 +115,10 @@ class ExceptionLogger extends Logger
     {
         return (isset($context['exception']) && ($context['exception'] instanceof \Exception)) ?
             $context['exception'] : null;
+    }
+
+    public function reset()
+    {
+        $this->decoratedLogger->reset();
     }
 }

--- a/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
+++ b/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
@@ -71,17 +71,16 @@ class ExceptionLogger extends Logger
      * @param  string $message The log message
      * @param  array $context  The log context
      *
-     * @return Boolean Whether the record has been processed
      * @throws \Exception Exception that occured
      * @throws \RuntimeException Log message as exception
      */
-    public function addRecord($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
+        $this->addRecord($level, $message, $context);
+
         if ($this->isTriggered($level)) {
             throw $this->getContextException($context) ?: new RuntimeException($message, $level);
         }
-
-        return parent::addRecord($level, $message, $context);
     }
 
     /**

--- a/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
+++ b/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
@@ -74,13 +74,15 @@ class ExceptionLogger extends Logger
      * @throws \Exception Exception that occured
      * @throws \RuntimeException Log message as exception
      */
-    public function log($level, $message, array $context = []): void
+    public function addRecord($level, $message, array $context = [])
     {
-        $this->addRecord($level, $message, $context);
+        $processed = parent::addRecord($level, $message, $context);
 
         if ($this->isTriggered($level)) {
             throw $this->getContextException($context) ?: new RuntimeException($message, $level);
         }
+
+        return $processed;
     }
 
     /**

--- a/src/Micrometa/Tests/Infrastructure/ExceptionLoggerTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ExceptionLoggerTest.php
@@ -45,7 +45,7 @@ use Jkphl\Micrometa\Tests\AbstractTestBase;
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Tests
  */
-class LoggerTest extends AbstractTestBase
+class ExceptionLoggerTest extends AbstractTestBase
 {
     /**
      * Test the exception logger

--- a/src/Micrometa/Tests/Infrastructure/ExceptionLoggerTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ExceptionLoggerTest.php
@@ -49,15 +49,6 @@ class ExceptionLoggerTest extends AbstractTestBase
 {
     /**
      * Test the exception logger
-     */
-    public function testExceptionLogger()
-    {
-        $logger = new ExceptionLogger();
-        $this->assertTrue($logger->debug('DEBUG'));
-    }
-
-    /**
-     * Test the exception logger
      *
      * @expectedException \Jkphl\Micrometa\Ports\Exceptions\RuntimeException
      * @expectedExceptionMessage CRITICAL


### PR DESCRIPTION
fixes #52 but requires #55 to be merged first

All logger usages comply to `psr/log`, so we can safely support Monolog 2.

Did also check the [Monolog UPGRADE notes](https://github.com/Seldaek/monolog/blob/master/UPGRADE.md) to be sure.

## RFC

* I'm in favor of bumping our PHP requirement from `^7.1.3` to `^7.2.5`