### PR TITLE
Support PHP7.4, upgrade PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-    - 7.1
     - 7.2
     - 7.3
+    - 7.4
 env:
     - APP_ENV=development CC_TEST_REPORTER_ID=efd18a36922628f0536f2f08cf7ceca763f5f2feb6f3638037381487ca3312ae
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+    - 7.1
     - 7.2
     - 7.3
     - 7.4
@@ -7,7 +8,7 @@ env:
     - APP_ENV=development CC_TEST_REPORTER_ID=efd18a36922628f0536f2f08cf7ceca763f5f2feb6f3638037381487ca3312ae
 matrix:
     allow_failures:
-        - php: hhvm
+        - php: 7.1
 before_script:
     - travis_retry composer self-update
     - travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "clue/graph-composer": "dev-master",
         "mf2/tests": "@dev",
         "mindplay/composer-locator": "^2.1",
-        "phpunit/phpunit": ">=7.0",
+        "phpunit/phpunit": "^8.5",
         "php-coveralls/php-coveralls": "^2.1",
         "squizlabs/php_codesniffer": "^3.3"
     }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2.5",
         "jkphl/dom-factory": "^0.1.2",
         "jkphl/rdfa-lite-microdata": "^0.4.4",
         "league/uri": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "clue/graph-composer": "dev-master",
         "mf2/tests": "@dev",
         "mindplay/composer-locator": "^2.1",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^7.0 || ^8.5",
         "php-coveralls/php-coveralls": "^2.1",
         "squizlabs/php_codesniffer": "^3.3"
     }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.1.3",
         "jkphl/dom-factory": "^0.1.2",
         "jkphl/rdfa-lite-microdata": "^0.4.4",
         "league/uri": "^5.0",

--- a/src/Micrometa/Tests/Application/ItemFactoryTest.php
+++ b/src/Micrometa/Tests/Application/ItemFactoryTest.php
@@ -175,12 +175,11 @@ class ItemFactoryTest extends AbstractTestBase
 
     /**
      * Test an invalid language tagged property value
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\RuntimeException
-     * @expectedExceptionCode 1495906369
      */
     public function testInvalidLanguageTaggedPropertyValue()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\RuntimeException');
+        $this->expectExceptionCode('1495906369');
         $itemFactory = new ItemFactory(0);
         $rawItem     = (object)[
             'type'       => ['test'],

--- a/src/Micrometa/Tests/Domain/IriTest.php
+++ b/src/Micrometa/Tests/Domain/IriTest.php
@@ -49,12 +49,11 @@ class IriTest extends AbstractTestBase
 {
     /**
      * Test IRIs
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1495895152
      */
     public function testIri()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1495895152');
         $profile = md5(rand());
         $name    = md5(rand());
         $iri     = new Iri($profile, $name);
@@ -70,12 +69,11 @@ class IriTest extends AbstractTestBase
 
     /**
      * Test IRI immutability
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\ErrorException
-     * @expectedExceptionCode 1495895278
      */
     public function testIriImmutability()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\ErrorException');
+        $this->expectExceptionCode('1495895278');
         $iri          = new Iri('', '');
         $iri->profile = 'abc';
     }

--- a/src/Micrometa/Tests/Domain/ItemTest.php
+++ b/src/Micrometa/Tests/Domain/ItemTest.php
@@ -197,67 +197,61 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test the item creation with an empty types list
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1490814631
      */
     public function testEmptyTypesList()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1490814631');
         new Item(null);
     }
 
     /**
      * Test the item creation with an empty types list
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1488314667
      */
     public function testEmptyTypeName()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1488314667');
         new Item('');
     }
 
     /**
      * Test the item creation with an empty property name
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1488314921
      */
     public function testEmptyPropertyName()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1488314921');
         new Item('type', [$this->prp('', 'value')]);
     }
 
     /**
      * Test empty property value list
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1490814554
      */
     public function testInvalidPropertyStructure()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1490814554');
         new Item('type', [(object)['invalid' => 'structure']]);
     }
 
     /**
      * Test the item creation with an invalid property value
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1488315339
      */
     public function testInvalidPropertyValue()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1488315339');
         new Item('type', [(object)['profile' => '', 'name' => 'test', 'values' => [123]]]);
     }
 
     /**
      * Test the item creation with an invalid property value
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1488315604
      */
     public function testUnknownPropertyName()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1488315604');
         $item = new Item('type');
         $item->getProperty('name');
     }

--- a/src/Micrometa/Tests/Domain/PropertyListTest.php
+++ b/src/Micrometa/Tests/Domain/PropertyListTest.php
@@ -52,12 +52,11 @@ class PropertyListTest extends AbstractTestBase
 {
     /**
      * Test the property list
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\ErrorException
-     * @expectedExceptionCode 1489784392
      */
     public function testPropertyList()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\ErrorException');
+        $this->expectExceptionCode('1489784392');
         $propertyList = new PropertyList();
         $this->assertInstanceOf(PropertyList::class, $propertyList);
         $this->assertEquals(0, count($propertyList));
@@ -139,12 +138,11 @@ class PropertyListTest extends AbstractTestBase
 
     /**
      * Test an unprofiled invalid property
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1488315604
      */
     public function testUnprofiledInvalidProperty()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1488315604');
         $propertyList = new PropertyList();
         $this->assertInstanceOf(PropertyList::class, $propertyList);
         $propertyList['invalid'];
@@ -152,12 +150,11 @@ class PropertyListTest extends AbstractTestBase
 
     /**
      * Test an profiled invalid property
-     *
-     * @expectedException \Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1488315604
      */
     public function testProfiledInvalidProperty()
     {
+        $this->expectException('Jkphl\Micrometa\Domain\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1488315604');
         $propertyList = new PropertyList();
         $this->assertInstanceOf(PropertyList::class, $propertyList);
         $propertyList->offsetGet((object)['name' => 'invalid', 'profile' => MicroformatsFactory::MF2_PROFILE_URI]);

--- a/src/Micrometa/Tests/Infrastructure/LoggerTest.php
+++ b/src/Micrometa/Tests/Infrastructure/LoggerTest.php
@@ -58,26 +58,24 @@ class LoggerTest extends AbstractTestBase
 
     /**
      * Test the exception logger
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\RuntimeException
-     * @expectedExceptionMessage CRITICAL
-     * @expectedExceptionCode    500
      */
     public function testNoContextExceptionLogger()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\RuntimeException');
+        $this->expectExceptionCode('500');
+        $this->expectExceptionMessage('CRITICAL');
         $logger = new ExceptionLogger();
         $logger->critical('CRITICAL');
     }
 
     /**
      * Test the exception logger with a context
-     *
-     * @expectedException \ErrorException
-     * @expectedExceptionMessage ERROR
-     * @expectedExceptionCode    1234
      */
     public function testContextExceptionLogger()
     {
+        $this->expectException('ErrorException');
+        $this->expectExceptionCode('1234');
+        $this->expectExceptionMessage('ERROR');
         $exception = new \ErrorException('ERROR', 1234);
         $logger    = new ExceptionLogger();
         $logger->critical('CRITICAL', ['exception' => $exception]);

--- a/src/Micrometa/Tests/Infrastructure/ProfiledNameFactoryTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ProfiledNameFactoryTest.php
@@ -47,7 +47,7 @@ use Jkphl\Micrometa\Tests\AbstractTestBase;
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Tests
  */
-class ProfiledNamesFactoryTest extends AbstractTestBase
+class ProfiledNameFactoryTest extends AbstractTestBase
 {
     /**
      * Test the profiled name factory
@@ -122,34 +122,31 @@ class ProfiledNamesFactoryTest extends AbstractTestBase
 
     /**
      * Test an invalid profiled name object
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1489528854
      */
     public function testInvalidObjectProfiledName()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1489528854');
         ProfiledNamesFactory::createFromArguments([(object)['missing' => 'name']]);
     }
 
     /**
      * Test an invalid profiled name array
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1491063221
      */
     public function testInvalidArrayProfiledName()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1491063221');
         ProfiledNamesFactory::createFromArguments([['invalid' => 'array']]);
     }
 
     /**
      * Test an invalid profiled name sting
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1489528854
      */
     public function testInvalidStringProfiledName()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1489528854');
         ProfiledNamesFactory::createFromArguments(['']);
     }
 }

--- a/src/Micrometa/Tests/Ports/ItemObjectModelTest.php
+++ b/src/Micrometa/Tests/Ports/ItemObjectModelTest.php
@@ -64,12 +64,11 @@ class ItemObjectModelTest extends AbstractTestBase
 
     /**
      * Test the item object model
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1489268571
      */
     public function testItemObjectModel()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1489268571');
         $xml = '<html/>';
         $dom = new \DOMDocument();
         $dom->loadXML($xml);

--- a/src/Micrometa/Tests/Ports/ItemTest.php
+++ b/src/Micrometa/Tests/Ports/ItemTest.php
@@ -79,12 +79,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test the item properties
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1491672553
      */
     public function testItemProperties()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1491672553');
         $feedItem = $this->getFeedItem();
         $this->assertInstanceOf(Item::class, $feedItem);
 
@@ -113,12 +112,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test an unprofiled property
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1488315604
      */
     public function testItemUnprofiledProperty()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1488315604');
         $feedItem = $this->getFeedItem();
         $this->assertInstanceOf(Item::class, $feedItem);
 
@@ -140,12 +138,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test a profiled property
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1488315604
      */
     public function testItemProfiledProperty()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1488315604');
         $feedItem = $this->getFeedItem();
         $this->assertInstanceOf(Item::class, $feedItem);
 
@@ -167,12 +164,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test an unprofiled property
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1488315604
      */
     public function testItemAliasedProperty()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1488315604');
         $feedItem = $this->getFeedItem();
         $this->assertInstanceOf(Item::class, $feedItem);
 
@@ -210,12 +206,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test a property stack
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1488315604
      */
     public function testItemPropertyStack()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1488315604');
         $feedItem = $this->getFeedItem();
         $this->assertInstanceOf(Item::class, $feedItem);
 
@@ -249,12 +244,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test nested items
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException
-     * @expectedExceptionCode 1492418709
      */
     public function testItemNestedItems()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException');
+        $this->expectExceptionCode('1492418709');
         $feedItem = $this->getFeedItem();
         $this->assertInstanceOf(Item::class, $feedItem);
 
@@ -295,12 +289,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test non-existent nested item
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1492418999
      */
     public function testItemNonExistentNestedItems()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1492418999');
         $feedItem = $this->getFeedItem();
         /** @noinspection PhpUndefinedMethodInspection */
         $this->assertEquals('John Doe', $feedItem->hEntry()->author->name);
@@ -310,12 +303,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test the item list export
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException
-     * @expectedExceptionCode 1492030227
      */
     public function testItemListExport()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectExceptionCode('1492030227');
         $feedItem = $this->getFeedItem();
         $itemList = new ItemList([$feedItem]);
         $this->assertInstanceOf(ItemList::class, $itemList);
@@ -331,12 +323,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test the item list immutability
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\RuntimeException
-     * @expectedExceptionCode 1495988721
      */
     public function testItemListImmutabilitySet()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\RuntimeException');
+        $this->expectExceptionCode('1495988721');
         $feedItem = $this->getFeedItem();
         $itemList = new ItemList([$feedItem]);
         $this->assertInstanceOf(ItemList::class, $itemList);
@@ -346,12 +337,11 @@ class ItemTest extends AbstractTestBase
 
     /**
      * Test the item list immutability
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\RuntimeException
-     * @expectedExceptionCode 1495988721
      */
     public function testItemListImmutabilityUnset()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\RuntimeException');
+        $this->expectExceptionCode('1495988721');
         $feedItem = $this->getFeedItem();
         $itemList = new ItemList([$feedItem]);
         $this->assertInstanceOf(ItemList::class, $itemList);

--- a/src/Micrometa/Tests/Ports/ParserTest.php
+++ b/src/Micrometa/Tests/Ports/ParserTest.php
@@ -62,12 +62,11 @@ class ParserTest extends AbstractTestBase
 
     /**
      * Test the JSON-LD parser with an invalid JSON-LD document
-     *
-     * @expectedException \Jkphl\Micrometa\Ports\Exceptions\RuntimeException
-     * @expectedExceptionCode 400
      */
     public function testJsonLDParser()
     {
+        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\RuntimeException');
+        $this->expectExceptionCode('400');
         $parser          = new Parser(Format::JSON_LD);
         $itemObjectModel = $parser('http://localhost:1349/json-ld/jsonld-invalid.html');
         $this->assertInstanceOf(ItemObjectModelInterface::class, $itemObjectModel);


### PR DESCRIPTION
Use rectorphp to auto-fix the BC breaks and deprecations on PHPUnit stable.

## Why?

* Allow testing on PHP7.4
* Allow bumping PHP version later on

## How to reproduce

Used the following command to perform this upgrade within seconds:

```
$ docker run --rm -v ${CURDIR}:/project -w /project jakzal/phpqa:php7.4-alpine rector process src/Micrometa/Tests --set phpunit80
```