### PR TITLE
Fix JsonLD recursion

### DIFF
--- a/src/Micrometa/Infrastructure/Parser/JsonLD.php
+++ b/src/Micrometa/Infrastructure/Parser/JsonLD.php
@@ -193,11 +193,11 @@ class JsonLD extends AbstractParser
      */
     protected function parseNode(NodeInterface $node)
     {
-        $id = $node->getId() ?: null;
+        $nodeId = $node->getId() ?: null;
 
         // if ID is in the current chain, just return the ID reference
         if (in_array($node, $this->chain, true)) {
-            return $id;
+            return $nodeId;
         }
 
         // add node to chain, parse node tree, remove node from chain
@@ -207,7 +207,7 @@ class JsonLD extends AbstractParser
 
         return (object)[
             'type'       => $this->parseNodeType($node),
-            'id'         => $id,
+            'id'         => $nodeId,
             'properties' => $properties,
         ];
     }

--- a/src/Micrometa/Tests/Fixture/json-ld/jsonld-recursion.html
+++ b/src/Micrometa/Tests/Fixture/json-ld/jsonld-recursion.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <meta charset="UTF-8">
+        <title>JSON-LD test document</title>
+        <script type="application/ld+json">
+            {
+                "@context": "http://schema.org/",
+                "@type": "Website",
+                "@id": "https://www.example.com/",
+                "url": "https://www.example.com/"
+            };
+        </script>
+    </head>
+    <body>
+        <h1>JSON-LD test document</h1>
+    </body>
+</html>

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -204,4 +204,20 @@ class ParserTest extends AbstractTestBase
         $this->assertEquals(LinkType::FORMAT, $items[0]->getFormat());
         $this->assertEquals([new Iri(LinkType::HTML_PROFILE_URI, 'icon')], $items[0]->getType());
     }
+
+    /**
+     * Test the JSON-LD parser with a valid recursion
+     */
+    public function testRecursionInJsonLDParser()
+    {
+        $items = $this->parseItems('json-ld/jsonld-recursion.html', JsonLD::class);
+        $this->assertTrue(is_array($items));
+        $this->assertInstanceOf(Item::class, $items[0]);
+
+        $url = $items[0]->getProperty('url');
+        $this->assertTrue(is_array($url));
+        $this->assertEquals(1, count($url));
+        $this->assertInstanceOf(StringValue::class, $url[0]);
+        $this->assertEquals('https://www.example.com/', strval($url[0]));
+    }
 }


### PR DESCRIPTION
fix #27, fix #29

As mentioned in [my comment](https://github.com/jkphl/micrometa/issues/29#issuecomment-559363499) previously, what lanthaler/JsonLD returns is valid, and only becomes a problem when we try to traverse the tree and end up resolving all the references, including those that resolve to a parent object.

We've been using this implementation for a few months without issues now, and I finally got around to submitting a PR.