### PR TITLE
Hotfix for broken schema.org context download

### DIFF
--- a/src/Micrometa/Infrastructure/Parser/JsonLD/CachingContextLoader.php
+++ b/src/Micrometa/Infrastructure/Parser/JsonLD/CachingContextLoader.php
@@ -73,6 +73,11 @@ class CachingContextLoader extends FileGetContentsLoader
      */
     public function loadDocument($url)
     {
+        // ML\JsonLD\FileGetContentsLoader is no longer able to fetch schema.org, this is a workaround
+        if (in_array(strtolower(rtrim($url, '/')), ['http://schema.org', 'https://schema.org'])) {
+            $url = 'https://schema.org/docs/jsonldcontext.jsonld';
+        }
+
         // Try to return a cached document
         $document = $this->vocabularyCache->getDocument($url);
         if ($document instanceof RemoteDocument) {


### PR DESCRIPTION
See:
- https://github.com/schemaorg/schemaorg/issues/2578
- https://github.com/lanthaler/JsonLD/issues/99

Basically, `Jkphl\Micrometa` relies on `ML\JsonLD`, but the latter is currently broken because schema.org disabled http content negotiation.  This affects all current and previous versions of `ML\JsonLD` and therefore all current and previous versions of `Jkphl\Micrometa`.

This fix manually forwards schema.org to the correct context file.