### PR TITLE
Valid JSON-LD rejected due to `$node->isBlankNode()`

### DIFF
--- a/src/Micrometa/Infrastructure/Parser/JsonLD.php
+++ b/src/Micrometa/Infrastructure/Parser/JsonLD.php
@@ -221,10 +221,6 @@ class JsonLD extends AbstractParser
      */
     protected function parseNodeType(NodeInterface $node): array
     {
-        if ($node->isBlankNode()) {
-            return [];
-        }
-
         /** @var NodeInterface|NodeInterface[] $itemTypes */
         $itemTypes = $node->getType();
         $itemTypes = is_array($itemTypes) ? $itemTypes : [$itemTypes];

--- a/src/Micrometa/Tests/Fixture/json-ld/jsonld-incorrect-empty-type-list.html
+++ b/src/Micrometa/Tests/Fixture/json-ld/jsonld-incorrect-empty-type-list.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Example from in-the-wild: https://cvp.com/product/sony_a7iii -->
+    <script type="application/ld+json">
+    {
+      "@context": "http://schema.org/",
+      "@type": "Product",
+      "name": "Sony a7 III Camera Body Only",
+      "image": "",
+      "description": "Sony a7 Mark III 24.2 Megapixel Full Frame Digital Camera with 4K HDR Video Recording - Body Only (p/n ILCE7M3B.CEC)",
+      "gtin": "4548736079656",
+      "sku": "192499",
+      "mpn": "ILCE7M3B.CEC",
+      "brand": {
+        "@type": "Thing",
+        "name": "Sony"
+      },
+      "offers": {
+        "@type": "Offer",
+        "url" : "https://cvp.com/product/sony_a7iii",
+        "priceCurrency": "GBP",
+        "price": "0.00",
+        "itemCondition": "http://schema.org/NewCondition",
+        "availability": "http://schema.org/OutOfStock",
+        "seller": {
+          "@type": "Organization",
+          "name": "CVP.com - Professional Video Cameras, Broadcast Camcorders"
+        }
+      }
+    }
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/Micrometa/Tests/Infrastructure/ParserTest.php
+++ b/src/Micrometa/Tests/Infrastructure/ParserTest.php
@@ -110,6 +110,20 @@ class ParserTest extends AbstractTestBase
     }
 
     /**
+     * Test the JSON-LD parser with example that was throwing an InvalidArgumentException.
+     * @see https://github.com/jkphl/micrometa/pull/59
+     */
+    public function testFixIncorrectEmptyTypeListInJsonLDParser()
+    {
+        $items = $this->parseItems('json-ld/jsonld-incorrect-empty-type-list.html', JsonLD::class, 0);
+        $this->assertTrue(is_array($items));
+        $this->assertEquals(1, count($items));
+
+        $type = $items[0]->getType();
+        $this->assertEquals('http://schema.org/Product', (string) $type[0]);
+    }
+
+    /**
      * Test the JSON-LD parser with an invalid document
      */
     public function testInvalidJsonLDParser()


### PR DESCRIPTION
JSON-LD triggers an InvalidArgumentException due to "Empty type list" but the type appears
to be present/valid on `ML\JsonLD\Node`. 

Removing the `$node->isBlankNode()` check resolves the issue and continues to return an empty array when no type is found.

For example JSON-LD, see https://cvp.com/product/sony_a7iii