### PR TITLE
hotfix broken schema.org headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "jkphl/rdfa-lite-microdata": "^0.4.4",
         "league/uri": "^5.0",
         "mf2/mf2": "^0.4",
-        "ml/json-ld": "^1.1",
+        "ml/json-ld": "^1.2",
         "monolog/monolog": "^1.24 || ^2",
         "psr/cache": "^1.0",
         "psr/log": "^1.1",


### PR DESCRIPTION
replaces #58

This PR bumps the `ml/json-ld` requirement, which fixes the change in the Schema.org Link headers.