### PR TITLE
Encapsulate ItemList inside Item instead of inheriting and exposing many unused public methods

### DIFF
--- a/src/Micrometa/Ports/Item/Collection.php
+++ b/src/Micrometa/Ports/Item/Collection.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Jkphl\Micrometa\Ports\Item;
+
+use Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException;
+use Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException;
+
+/**
+ * Abstract getter functionality that is applicable for implementations of ItemCollectionFacade.
+ *
+ * The implementation remains responsible for implementing the collection methods itself.
+ *
+ * Thereby is usable by both the Item for it's properties, as for an ItemList with it's items.
+ *
+ * @package    Jkphl\Micrometa
+ * @subpackage Jkphl\Micrometa\Ports
+ */
+abstract class Collection implements CollectionFacade
+{
+    /**
+     * Generic item getter
+     *
+     * @param string $type     Item type
+     * @param array $arguments Arguments
+     *
+     * @return ItemInterface Item
+     * @throws InvalidArgumentException If the item index is invalid
+     * @api
+     */
+    public function __call($type, $arguments)
+    {
+        $index = 0;
+        if (count($arguments)) {
+            // If the item index is invalid
+            if (!is_int($arguments[0]) || ($arguments[0] < 0)) {
+                throw new InvalidArgumentException(
+                    sprintf(InvalidArgumentException::INVALID_ITEM_INDEX_STR, $arguments[0]),
+                    InvalidArgumentException::INVALID_ITEM_INDEX
+                );
+            }
+
+            $index = $arguments[0];
+        }
+
+        // Return the item by type and index
+        return $this->getItemByTypeAndIndex($type, $index);
+    }
+
+    /**
+     * Return an item by type and index
+     *
+     * @param string $type Item type
+     * @param int $index   Item index
+     *
+     * @return ItemInterface Item
+     * @throws OutOfBoundsException If the item index is out of bounds
+     */
+    private function getItemByTypeAndIndex($type, $index)
+    {
+        $typeItems = $this->getItems($type);
+
+        // If the item index is out of bounds
+        if (count($typeItems) <= $index) {
+            throw new OutOfBoundsException(
+                sprintf(OutOfBoundsException::INVALID_ITEM_INDEX_STR, $index),
+                OutOfBoundsException::INVALID_ITEM_INDEX
+            );
+        }
+
+        return $typeItems[$index];
+    }
+}

--- a/src/Micrometa/Ports/Item/CollectionFacade.php
+++ b/src/Micrometa/Ports/Item/CollectionFacade.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Jkphl\Micrometa\Ports\Item;
+
+/**
+ * Interface to hides all other methods that ItemListInterface inherits from PHP core.
+ *
+ * Thereby is usable by both the Item for it's properties, as for an ItemList with it's items.
+ *
+ * Prefer type-hinting against this facade over the ItemList interface.
+ *
+ * @see ItemListInterface
+ *
+ * @package    Jkphl\Micrometa
+ * @subpackage Jkphl\Micrometa\Ports
+ */
+interface CollectionFacade extends \Countable
+{
+    /**
+     * Return an object representation of the item list
+     *
+     * @return \stdClass Micro information items
+     * @api
+     */
+    public function toObject();
+
+    /**
+     * Filter the items by item type(s)
+     *
+     * @param string[] $types Item types
+     *
+     * @return ItemInterface[] Items matching the requested types
+     * @api
+     */
+    public function getItems(...$types);
+
+    /**
+     * Return the first item, optionally of particular types
+     *
+     * @param string[] $types Item types
+     *
+     * @return ItemInterface Item
+     * @api
+     */
+    public function getFirstItem(...$types);
+}

--- a/src/Micrometa/Ports/Item/Item.php
+++ b/src/Micrometa/Ports/Item/Item.php
@@ -55,7 +55,7 @@ use Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException;
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Ports
  */
-class Item extends ItemList implements ItemInterface
+class Item extends Collection implements ItemInterface
 {
     /**
      * Application item
@@ -65,6 +65,11 @@ class Item extends ItemList implements ItemInterface
     protected $item;
 
     /**
+     * @var ItemList
+     */
+    private $itemList;
+
+    /**
      * Item constructor
      *
      * @param ApplicationItemInterface $item Application item
@@ -72,7 +77,7 @@ class Item extends ItemList implements ItemInterface
     public function __construct(ApplicationItemInterface $item)
     {
         $this->item = $item;
-        parent::__construct(ItemFactory::createFromApplicationItems($this->item->getChildren()));
+        $this->itemList = new ItemList(ItemFactory::createFromApplicationItems($this->item->getChildren()));
     }
 
     /**
@@ -327,5 +332,39 @@ class Item extends ItemList implements ItemInterface
     public function getValue()
     {
         return $this->item->getValue();
+    }
+
+    /**
+     * Filter the items by item type(s).
+     *
+     * @param array ...$types Item types
+     *
+     * @return ItemInterface[] Items matching the requested types
+     */
+    public function getItems(...$types)
+    {
+        return $this->itemList->getItems(...$types);
+    }
+
+    /**
+     * Return the first item, optionally of particular types.
+     *
+     * @param array ...$types Item types
+     *
+     * @return ItemInterface Item
+     */
+    public function getFirstItem(...$types)
+    {
+        return $this->itemList->getFirstItem(...$types);
+    }
+
+    /**
+     * Count the elements in the item list.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->itemList->count();
     }
 }

--- a/src/Micrometa/Ports/Item/ItemInterface.php
+++ b/src/Micrometa/Ports/Item/ItemInterface.php
@@ -45,7 +45,7 @@ use Jkphl\Micrometa\Application\Item\PropertyListInterface;
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Ports
  */
-interface ItemInterface extends ItemListInterface
+interface ItemInterface
 {
     /**
      * Return whether the item is of a particular type (or contained in a list of types)

--- a/src/Micrometa/Ports/Item/ItemList.php
+++ b/src/Micrometa/Ports/Item/ItemList.php
@@ -36,17 +36,16 @@
 
 namespace Jkphl\Micrometa\Ports\Item;
 
-use Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException;
 use Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException;
 use Jkphl\Micrometa\Ports\Exceptions\RuntimeException;
 
 /**
- * Abstract item list
+ * Item list
  *
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Ports
  */
-class ItemList implements ItemListInterface
+class ItemList extends Collection implements ItemListInterface
 {
     /**
      * Items
@@ -254,58 +253,5 @@ class ItemList implements ItemListInterface
     public function count()
     {
         return count($this->items);
-    }
-
-    /**
-     * Generic item getter
-     *
-     * @param string $type     Item type
-     * @param array $arguments Arguments
-     *
-     * @return ItemInterface Item
-     * @throws InvalidArgumentException If the item index is invalid
-     * @api
-     */
-    public function __call($type, $arguments)
-    {
-        $index = 0;
-        if (count($arguments)) {
-            // If the item index is invalid
-            if (!is_int($arguments[0]) || ($arguments[0] < 0)) {
-                throw new InvalidArgumentException(
-                    sprintf(InvalidArgumentException::INVALID_ITEM_INDEX_STR, $arguments[0]),
-                    InvalidArgumentException::INVALID_ITEM_INDEX
-                );
-            }
-
-            $index = $arguments[0];
-        }
-
-        // Return the item by type and index
-        return $this->getItemByTypeAndIndex($type, $index);
-    }
-
-    /**
-     * Return an item by type and index
-     *
-     * @param string $type Item type
-     * @param int $index   Item index
-     *
-     * @return ItemInterface Item
-     * @throws OutOfBoundsException If the item index is out of bounds
-     */
-    protected function getItemByTypeAndIndex($type, $index)
-    {
-        $typeItems = $this->getItems($type);
-
-        // If the item index is out of bounds
-        if (count($typeItems) <= $index) {
-            throw new OutOfBoundsException(
-                sprintf(OutOfBoundsException::INVALID_ITEM_INDEX_STR, $index),
-                OutOfBoundsException::INVALID_ITEM_INDEX
-            );
-        }
-
-        return $typeItems[$index];
     }
 }

--- a/src/Micrometa/Ports/Item/ItemListInterface.php
+++ b/src/Micrometa/Ports/Item/ItemListInterface.php
@@ -39,36 +39,11 @@ namespace Jkphl\Micrometa\Ports\Item;
 /**
  * Item list interface
  *
+ * Prefer type-hinting against CollectionFacade over this interface to narrow-down the number of public methods.
+ *
  * @package    Jkphl\Micrometa
  * @subpackage Jkphl\Micrometa\Ports
  */
-interface ItemListInterface extends \Iterator, \Countable, \ArrayAccess
+interface ItemListInterface extends CollectionFacade, \Iterator, \ArrayAccess
 {
-    /**
-     * Return an object representation of the item list
-     *
-     * @return \stdClass Micro information items
-     * @api
-     */
-    public function toObject();
-
-    /**
-     * Filter the items by item type(s)
-     *
-     * @param array ...$types Item types
-     *
-     * @return ItemInterface[] Items matching the requested types
-     * @api
-     */
-    public function getItems(...$types);
-
-    /**
-     * Return the first item, optionally of particular types
-     *
-     * @param array ...$types Item types
-     *
-     * @return ItemInterface Item
-     * @api
-     */
-    public function getFirstItem(...$types);
 }

--- a/src/Micrometa/Tests/Micrometa/Ports/Item/ItemListTest.php
+++ b/src/Micrometa/Tests/Micrometa/Ports/Item/ItemListTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Micrometa\Ports\Item;
+
+use Jkphl\Micrometa\Infrastructure\Factory\MicroformatsFactory;
+use Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException;
+use Jkphl\Micrometa\Ports\Item\ItemInterface;
+use Jkphl\Micrometa\Ports\Item\ItemList;
+use Jkphl\Micrometa\Tests\MicroformatsFeedTrait;
+use PHPUnit\Framework\TestCase;
+
+class ItemListTest extends TestCase
+{
+    /**
+     * Use the Microformats feed method
+     */
+    use MicroformatsFeedTrait;
+
+    private $feedItemList;
+
+    protected function setUp(): void
+    {
+        $this->feedItemList = new ItemList([$this->getFeedItem(), $this->getFeedItem()]);
+    }
+
+    public function testNestedItemsCounts()
+    {
+        // Test the number of nested items
+        self::assertCount(2, $this->feedItemList);
+        self::assertCount(2, $this->feedItemList->getItems());
+    }
+
+    public function testNestedItemsIteration()
+    {
+        foreach ($this->feedItemList->getItems() as $itemIndex => $entryItem) {
+            self::assertInstanceOf(ItemInterface::class, $entryItem);
+            self::assertIsInt($itemIndex);
+        }
+    }
+
+    public function testNestedItemsRetrievalViaArrayAccess()
+    {
+        $entryItems = $this->feedItemList->getFirstItem()->getItems('h-entry');
+        $entryItem = $entryItems[1];
+
+        self::assertInstanceOf(ItemInterface::class, $entryItem);
+    }
+
+    public function testFirstNestedItemRetrieval()
+    {
+        self::assertInstanceOf(ItemInterface::class, $this->feedItemList[0]->getFirstItem('h-entry'));
+        self::assertInstanceOf(
+            ItemInterface::class,
+            $this->feedItemList[0]->getFirstItem('h-entry', MicroformatsFactory::MF2_PROFILE_URI)
+        );
+    }
+
+    public function testExistingFirstNestedItem()
+    {
+        self::assertEquals('John Doe', $this->feedItemList[0]->hEntry()->author->name);
+        self::assertEquals('John Doe', $this->feedItemList->getFirstItem()->hEntry()->author->name);
+    }
+
+    public function testNonExistingSecondNestedItem()
+    {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionCode('1492418999');
+
+        $this->feedItemList->hEntry(2);
+    }
+}

--- a/src/Micrometa/Tests/Ports/ItemTest.php
+++ b/src/Micrometa/Tests/Ports/ItemTest.php
@@ -44,6 +44,7 @@ use Jkphl\Micrometa\Ports\Item\ItemInterface;
 use Jkphl\Micrometa\Ports\Item\ItemList;
 use Jkphl\Micrometa\Tests\AbstractTestBase;
 use Jkphl\Micrometa\Tests\MicroformatsFeedTrait;
+use Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException;
 
 /**
  * Parser factory tests
@@ -247,10 +248,8 @@ class ItemTest extends AbstractTestBase
      */
     public function testItemNestedItems()
     {
-        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\InvalidArgumentException');
-        $this->expectExceptionCode('1492418709');
         $feedItem = $this->getFeedItem();
-        $this->assertInstanceOf(Item::class, $feedItem);
+        self::assertInstanceOf(Item::class, $feedItem);
 
         // Test the number of nested items
         $this->assertEquals(2, count($feedItem));
@@ -266,38 +265,21 @@ class ItemTest extends AbstractTestBase
         );
 
         // Test the second entry item
-        $this->runFeedNestedEntryItemTest($feedItem);
-    }
-
-    /**
-     * Test a nested entry item
-     *
-     * @param ItemInterface $feedItem Feed item
-     */
-    protected function runFeedNestedEntryItemTest(ItemInterface $feedItem)
-    {
         $entryItem = $feedItem->getItems('h-entry')[1];
-        $this->assertInstanceOf(ItemInterface::class, $entryItem);
-
-        // Test the magic item getter / item type aliases
-        /** @noinspection PhpUndefinedMethodInspection */
-        $entryItem = $feedItem->hEntry(0);
-        $this->assertInstanceOf(ItemInterface::class, $entryItem);
-        /** @noinspection PhpUndefinedMethodInspection */
-        $feedItem->hEntry(-1);
+        self::assertInstanceOf(ItemInterface::class, $entryItem);
     }
 
     /**
      * Test non-existent nested item
      */
-    public function testItemNonExistentNestedItems()
+    public function testNonExistentNestedItems()
     {
-        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionCode('1492418999');
+
         $feedItem = $this->getFeedItem();
-        /** @noinspection PhpUndefinedMethodInspection */
+
         $this->assertEquals('John Doe', $feedItem->hEntry()->author->name);
-        /** @noinspection PhpUndefinedMethodInspection */
         $feedItem->hEntry(2);
     }
 
@@ -306,8 +288,9 @@ class ItemTest extends AbstractTestBase
      */
     public function testItemListExport()
     {
-        $this->expectException('Jkphl\Micrometa\Ports\Exceptions\OutOfBoundsException');
+        $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionCode('1492030227');
+
         $feedItem = $this->getFeedItem();
         $itemList = new ItemList([$feedItem]);
         $this->assertInstanceOf(ItemList::class, $itemList);


### PR DESCRIPTION
replaces #51

fixes #50 

To stay in control over the public interface on `Item` and `ItemList`, the list with items has to get encapsulated inside the `Item`.