### PR TITLE
Stable jkphl/dom-factory support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=7.1.3",
-        "jkphl/dom-factory": "^0.1.2",
+        "jkphl/dom-factory": "^0.1.2 || ^1",
         "jkphl/rdfa-lite-microdata": "^0.4.4",
         "league/uri": "^5.0",
         "mf2/mf2": "^0.4",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=7.1.3",
-        "jkphl/dom-factory": "^0.1.2 || ^1",
+        "jkphl/dom-factory": "^1",
         "jkphl/rdfa-lite-microdata": "^0.4.4",
         "league/uri": "^5.0",
         "mf2/mf2": "^0.4",


### PR DESCRIPTION
micrometa only support dom-factory versions < 1 now. Should also support the stable versions 1 of dom-factory