### PR TITLE
update league/uri, mf2/mf2, psr/cache, psr/log, and add ext-dom

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,7 @@
         "issues": "https://github.com/jkphl/micrometa/issues"
     },
     "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "mindplay/composer-locator": false
-        }
+        "sort-packages": true
     },
     "require": {
         "php": ">=7.1.3",

--- a/composer.json
+++ b/composer.json
@@ -19,18 +19,22 @@
         "issues": "https://github.com/jkphl/micrometa/issues"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "mindplay/composer-locator": false
+        }
     },
     "require": {
         "php": ">=7.1.3",
+        "ext-dom": "*",
         "jkphl/dom-factory": "^1",
         "jkphl/rdfa-lite-microdata": "^0.4.4",
-        "league/uri": "^5.0",
-        "mf2/mf2": "^0.4",
+        "league/uri": "^6.5",
+        "mf2/mf2": "^0.5",
         "ml/json-ld": "^1.2",
         "monolog/monolog": "^1.24 || ^2",
-        "psr/cache": "^1.0",
-        "psr/log": "^1.1",
+        "psr/cache": "^1.0|^2|^3",
+        "psr/log": "^1.1|^2|^3",
         "symfony/cache": "^4.0|^5.0"
     },
     "autoload": {


### PR DESCRIPTION
Made changes to enable broader compatibility with the new versions of psr/cache, psr/log, and league/uri. 
Also added ext-dom which should be a required dependency.
and updated mf2/mf2 since we're already here and that appears to be compatible without any other changes