### PR TITLE
Remove composer-locator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "jkphl/micrometa",
     "description": "A meta parser for extracting micro information out of web documents, currently supporting Microformats 1+2, HTML Microdata, RDFa Lite 1.1 and JSON-LD",
     "homepage": "https://jkphl.is/projects/micrometa/",
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "license": "MIT",
     "authors": [
@@ -48,7 +47,6 @@
     "require-dev": {
         "clue/graph-composer": "^1.1",
         "mf2/tests": "@dev",
-        "mindplay/composer-locator": "^2.1",
         "phpunit/phpunit": "^7.0 || ^8.5",
         "php-coveralls/php-coveralls": "^2.1",
         "squizlabs/php_codesniffer": "^3.3"

--- a/src/Micrometa/Tests/Application/ExtractorTest.php
+++ b/src/Micrometa/Tests/Application/ExtractorTest.php
@@ -36,7 +36,6 @@
 
 namespace Jkphl\Micrometa\Tests\Application;
 
-use ComposerLocator;
 use DOMDocument;
 use Jkphl\Domfactory\Ports\Dom;
 use Jkphl\Micrometa\Application\Contract\ParsingResultInterface;
@@ -106,7 +105,7 @@ class ExtractorTest extends AbstractTestBase
      */
     public function testMicroformatsExtraction()
     {
-        $microformatsTests = ComposerLocator::getPath('mf2/tests').DIRECTORY_SEPARATOR.'tests'.
+        $microformatsTests = dirname(__DIR__).DIRECTORY_SEPARATOR.'Fixture'.
                              DIRECTORY_SEPARATOR.'microformats-v2'.DIRECTORY_SEPARATOR;
 
         $this->getAndTestMicroformatsExtractionBase(

--- a/src/Micrometa/Tests/Fixture/microformats-v2/h-product/aggregate.html
+++ b/src/Micrometa/Tests/Fixture/microformats-v2/h-product/aggregate.html
@@ -1,0 +1,21 @@
+<meta charset="utf-8">
+<div class="h-product">
+    <h2 class="p-name">Raspberry Pi</h2>
+    <img class="u-photo" src="http://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/RaspberryPi.jpg/320px-RaspberryPi.jpg" />
+    <p class="e-description">The Raspberry Pi is a credit-card sized computer that plugs into your TV and a keyboard. It’s a capable little PC which can be used for many of the things that your desktop PC does, like spreadsheets, word-processing and games. It also plays high-definition video. We want to see it being used by kids all over the world to learn programming.</p>
+    <a class="u-url" href="http://www.raspberrypi.org/">More info about the Raspberry Pi</a>
+    <p class="p-price">£29.95</p>
+    <p class="p-review h-review-aggregate">
+        <span class="p-rating h-rating">
+            <span class="p-average">9.2</span> out of
+            <span class="p-best">10</span>
+            based on <span class="p-count">178</span> reviews
+        </span>
+    </p>
+    <p>Categories: <span class="p-category">Computer</span>, <span class="p-category">Education</span></p>
+    <p class="p-brand h-card">From:
+        <span class="p-name p-org">The Raspberry Pi Foundation</span> -
+        <span class="p-locality">Cambridge</span>
+        <span class="p-country-name">UK</span>
+    </p>
+</div>


### PR DESCRIPTION
Because this contains a plugin it prompts on every composer execution,
```
mindplay/composer-locator contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "mindplay/composer-locator" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
```

rather than enable the plugin, why not just remove this since it's so sparsely used?

I've also bundled in a `"minimum-stability": "dev"` change here because I don't see any reason why this would need a minimum stability of dev. Old artifact maybe?