### PR TITLE
Fix Declaration of ExceptionLogger::log

### DIFF
--- a/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
+++ b/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php
@@ -82,7 +82,7 @@ final class ExceptionLogger implements LoggerInterface, ResettableInterface
      * @throws \Exception Exception that occured
      * @throws \RuntimeException Log message as exception
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $level = Logger::toMonologLevel($level);
         if ($level instanceof Level) {


### PR DESCRIPTION
Declaration of Jkphl\Micrometa\Infrastructure\Logger\ExceptionLogger::log($level, $message, array $context = []) must be compatible with Psr\Log\LoggerTrait::log($level, Stringable|string $message, array $context = []): void {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Declaration of Jkphl\\Micrometa\\Infrastructure\\Logger\\ExceptionLogger::log($level, $message, array $context = []) must be compatible with Psr\\Log\\LoggerTrait::log($level, Stringable|string $message, array $context = []): void at /vendor/jkphl/micrometa/src/Micrometa/Infrastructure/Logger/ExceptionLogger.php:85)