### PR TITLE
Allow symfony 7 and 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "monolog/monolog": "^1.24 || ^2 || ^3",
         "psr/cache": "^1.0|^2|^3",
         "psr/log": "^1.1|^2|^3",
-        "symfony/cache": "^4.0|^5.0|^6.0"
+        "symfony/cache": "^4.0|^5.0|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The current requirements prevent installation on modern symfony versions.

As this is only used for ArrayAdapter whose interface was not changed, this is just an change in the composer.json